### PR TITLE
open file as utf-8

### DIFF
--- a/python/apps/controls-gallery/gallerydata.py
+++ b/python/apps/controls-gallery/gallerydata.py
@@ -170,7 +170,7 @@ ft.app(target=main)
                             grid_item.description = module.description
                         else:
                             example_item = ExampleItem()
-                            with open(file=file_path) as file_to_read:
+                            with open(file=file_path, encoding="utf-8") as file_to_read:
                                 code_text = format_code(
                                     file_to_read.read(), module.name
                                 )


### PR DESCRIPTION
there are non ascii characters in python\apps\controls-gallery\displays\markdown\01_markdown_with_githubweb_extensions_and_clickable_links.py . So the OPEN should be utf-8, otherwise in non English Windows, there's an error occurred.