### PR TITLE
Fix solitaire bugs

### DIFF
--- a/python/tutorials/solitaire/solitaire-final/card.py
+++ b/python/tutorials/solitaire/solitaire-final/card.py
@@ -27,15 +27,15 @@ class Card(ft.GestureDetector):
     def turn_face_up(self):
         self.face_up = True
         self.content.content.src=f"/images/{self.rank.name}_{self.suite.name}.svg"
-        self.update()
+        self.solitaire.update()
 
-    
+
     def turn_face_down(self):
         self.face_up = False
         #self.content.content.src=f"/images/card_back.svg"
         self.content.content.src=self.solitaire.settings.card_back
-        self.update()
-    
+        self.solitaire.update()
+
     def can_be_moved(self):
         if self.face_up and self.slot.type != 'waste':
             return True
@@ -51,7 +51,7 @@ class Card(ft.GestureDetector):
             # remember card original position to return it back if needed
             self.solitaire.current_top = e.control.top
             self.solitaire.current_left = e.control.left
-            # self.page.update()
+            self.solitaire.update()
 
     def drag(self, e: ft.DragUpdateEvent):
         if self.can_be_moved():
@@ -62,7 +62,7 @@ class Card(ft.GestureDetector):
                     card.top += i * self.solitaire.card_offset
                 card.left = max(0, self.left + e.delta_x)
                 i += 1
-                card.update()
+            self.solitaire.update()
 
     def drop(self, e: ft.DragEndEvent):
         if self.can_be_moved():
@@ -74,7 +74,7 @@ class Card(ft.GestureDetector):
                 if (
                     abs(self.top - slot.upper_card_top()) < 40
                     and abs(self.left - slot.left) < 40
-                ):  
+                ):
                     if (
                         slot.type == "tableau"
                         and self.solitaire.check_tableau_rules(
@@ -95,13 +95,13 @@ class Card(ft.GestureDetector):
                         #if len(old_slot.pile) > 0 and old_slot.type == "tableau":
                         #    old_slot.get_top_card().turn_face_up()
                         self.solitaire.display_waste()
-                        self.page.update()
+                        self.solitaire.update()
 
                         return
 
             # return card to original position
             self.solitaire.bounce_back(cards_to_drag)
-            self.page.update()
+            self.solitaire.update()
 
     def doubleclick(self, e):
         if self.slot.type in ("waste", "tableau"):
@@ -116,7 +116,7 @@ class Card(ft.GestureDetector):
                         #if len(old_slot.pile) > 0:
                             #old_slot.get_top_card().turn_face_up()
                         self.solitaire.display_waste()
-                        self.page.update()
+                        self.solitaire.update()
                         return
 
     def click(self, e):
@@ -130,7 +130,7 @@ class Card(ft.GestureDetector):
                 top_card.place(self.solitaire.waste)
                 top_card.turn_face_up()
             self.solitaire.display_waste()
-            self.page.update()
+            self.solitaire.update()
 
         if self.slot.type == "tableau":
             if self.face_up == False and len(self.slot.pile)-1 == self.slot.pile.index(self):
@@ -157,7 +157,7 @@ class Card(ft.GestureDetector):
         self.solitaire.move_on_top([self])
         if self.solitaire.check_if_you_won():
             self.solitaire.on_win()
-        self.update()
+        self.solitaire.update()
 
     def get_cards_to_move(self):
         """returns list of cards that will be dragged together, starting with the current card"""

--- a/python/tutorials/solitaire/solitaire-final/card.py
+++ b/python/tutorials/solitaire/solitaire-final/card.py
@@ -92,9 +92,10 @@ class Card(ft.GestureDetector):
                         for card in cards_to_drag:
                             card.place(slot)
                         # reveal top card in old tableau slot if exists
-                        #if len(old_slot.pile) > 0 and old_slot.type == "tableau":
-                        #    old_slot.get_top_card().turn_face_up()
-                        self.solitaire.display_waste()
+                        if len(old_slot.pile) > 0 and old_slot.type == "tableau":
+                           old_slot.get_top_card().turn_face_up()
+                        # elif old_slot.type == 'waste' and len(self.solitaire.waste.pile) == 0:
+                            # self.solitaire.display_waste()
                         self.solitaire.update()
 
                         return
@@ -115,7 +116,7 @@ class Card(ft.GestureDetector):
                         self.place(slot)
                         #if len(old_slot.pile) > 0:
                             #old_slot.get_top_card().turn_face_up()
-                        self.solitaire.display_waste()
+                        # self.solitaire.display_waste()
                         self.solitaire.update()
                         return
 


### PR DESCRIPTION
Addresses the following solitaire tutorial bugs:
* game does not load because card.update() cannot be called before card is added to page during solitaire mount() operations: `assert self.__page, "Control must be added to the page first."`
* cards cannot be moved due to other card.update() operations raising the same error
* double-clicking a card causes stock to be clicked. (display_waste() called when perhaps it wasn't supposed to be)
* card dragging was not being displayed, although drop/place worked fine.

Fixes applied:
* updated all card.update() calls to self.solitaire.update(), which might effect performance (?) but functions as expected in my few playthroughs
* commented out display_waste() calls, which appear to be unnecessary