### PR TITLE
Fixed building-views-on-route-change.py |  View parameter incompatibility for browser

### DIFF
--- a/python/apps/routing-navigation/building-views-on-route-change.py
+++ b/python/apps/routing-navigation/building-views-on-route-change.py
@@ -64,4 +64,4 @@ def main(page: Page):
     page.go(page.route)
 
 
-flet.app(target=main, view=flet.WEB_BROWSER)
+flet.app(target=main, view=flet.AppView.WEB_BROWSER)


### PR DESCRIPTION
Error that type cannot 'web browser' cannot be assigned to the view parameter which is of type 'AppView' Added AppView to avoid the it