### PR TITLE
fixed "'NoneType' object has no attribute 'width'"" bug on "trolli" example

### DIFF
--- a/python/apps/trolli/src/main.py
+++ b/python/apps/trolli/src/main.py
@@ -71,7 +71,6 @@ class TrelloApp(UserControl):
         return self.layout
 
     def initialize(self):
-        self.page.views.clear()
         self.page.views.append(
             View(
                 "/",


### PR DESCRIPTION
its just one line, I dont know why that line was there to begin with, I hope this fix will be merged bc it's really a simple fix and its kinda hard for beginers to learn how to use flet when one of the examples is broken