### PR TITLE
Update splash-test.py

### DIFF
--- a/python/controls/page/splash-test.py
+++ b/python/controls/page/splash-test.py
@@ -6,11 +6,11 @@ from flet import ElevatedButton, ProgressBar
 
 def main(page):
     def button_click(e):
-        page.splash = ProgressBar()
+        page.overlay.append(ProgressBar())
         btn.disabled = True
         page.update()
         sleep(3)
-        page.splash = None
+        page.overlay.clear()
         btn.disabled = False
         page.update()
 


### PR DESCRIPTION
The "splash" property has been deprecated in recent versions of Flet. This patch updates the code to address this issue.