### PR TITLE
Update app-exit-confirm-dialog.py

### DIFF
--- a/python/controls/page/app-exit-confirm-dialog.py
+++ b/python/controls/page/app-exit-confirm-dialog.py
@@ -1,21 +1,22 @@
 import flet
 from flet import AlertDialog, ElevatedButton, OutlinedButton, Page, Text
 
-
 def main(page: Page):
     page.title = "MyApp"
 
     def window_event(e):
         if e.data == "close":
-            page.dialog = confirm_dialog
+            # Use the updated method to append the dialog to the overlay
+            page.overlay.append(confirm_dialog)
             confirm_dialog.open = True
             page.update()
 
-    page.window_prevent_close = True
-    page.on_window_event = window_event
+    page.window.prevent_close = True
+    page.window.on_event = window_event
 
     def yes_click(e):
-        page.window_destroy()
+        # Use the updated method to destroy the window
+        page.window.destroy()
 
     def no_click(e):
         confirm_dialog.open = False
@@ -34,5 +35,5 @@ def main(page: Page):
 
     page.add(Text('Try exiting this app by clicking window\'s "Close" button!'))
 
-
+flet.app(target=main)
 flet.app(target=main, view=flet.FLET_APP)


### PR DESCRIPTION
Resolves the following deprecation errors:
window_prevent_close()
dialog()
window_destroy()