### PR TITLE
Update splash-test.py

### DIFF
--- a/python/controls/page/splash-test.py
+++ b/python/controls/page/splash-test.py
@@ -1,22 +1,21 @@
 from time import sleep
-
-import flet
+import flet as ft
 from flet import ElevatedButton, ProgressBar
-
 
 def main(page):
     def button_click(e):
-        page.splash = ProgressBar()
+        my_bar = ProgressBar()
+        
+        page.overlay.append(my_bar)
         btn.disabled = True
         page.update()
         sleep(3)
-        page.splash = None
+
+        page.overlay.remove(my_bar)
         btn.disabled = False
         page.update()
 
     btn = ElevatedButton("Do some lengthy task!", on_click=button_click)
-
     page.add(btn)
 
-
-flet.app(target=main)
+ft.app(target=main)


### PR DESCRIPTION
The "splash" property has been deprecated in recent versions of Flet, this patch updates the code to address this issue.

Additionally as per request (https://github.com/flet-dev/examples/pull/165#issuecomment-2346872098)  the bar is now stored in a variable, and we use page.overlay.remove(my_bar) to remove it