### PR TITLE
Fix deprecated codes in chat example

### DIFF
--- a/python/tutorials/chat/chat.py
+++ b/python/tutorials/chat/chat.py
@@ -15,7 +15,7 @@ class ChatMessage(ft.Row):
         self.controls = [
             ft.CircleAvatar(
                 content=ft.Text(self.get_initials(message.user_name)),
-                color=ft.colors.WHITE,
+                color=ft.Colors.WHITE,
                 bgcolor=self.get_avatar_color(message.user_name),
             ),
             ft.Column(
@@ -36,19 +36,19 @@ class ChatMessage(ft.Row):
 
     def get_avatar_color(self, user_name: str):
         colors_lookup = [
-            ft.colors.AMBER,
-            ft.colors.BLUE,
-            ft.colors.BROWN,
-            ft.colors.CYAN,
-            ft.colors.GREEN,
-            ft.colors.INDIGO,
-            ft.colors.LIME,
-            ft.colors.ORANGE,
-            ft.colors.PINK,
-            ft.colors.PURPLE,
-            ft.colors.RED,
-            ft.colors.TEAL,
-            ft.colors.YELLOW,
+            ft.Colors.AMBER,
+            ft.Colors.BLUE,
+            ft.Colors.BROWN,
+            ft.Colors.CYAN,
+            ft.Colors.GREEN,
+            ft.Colors.INDIGO,
+            ft.Colors.LIME,
+            ft.Colors.ORANGE,
+            ft.Colors.PINK,
+            ft.Colors.PURPLE,
+            ft.Colors.RED,
+            ft.Colors.TEAL,
+            ft.Colors.YELLOW,
         ]
         return colors_lookup[hash(user_name) % len(colors_lookup)]
 
@@ -91,7 +91,7 @@ def main(page: ft.Page):
         if message.message_type == "chat_message":
             m = ChatMessage(message)
         elif message.message_type == "login_message":
-            m = ft.Text(message.text, italic=True, color=ft.colors.BLACK45, size=12)
+            m = ft.Text(message.text, italic=True, color=ft.Colors.BLACK45, size=12)
         chat.controls.append(m)
         page.update()
 
@@ -135,7 +135,7 @@ def main(page: ft.Page):
     page.add(
         ft.Container(
             content=chat,
-            border=ft.border.all(1, ft.colors.OUTLINE),
+            border=ft.border.all(1, ft.Colors.OUTLINE),
             border_radius=5,
             padding=10,
             expand=True,
@@ -144,7 +144,7 @@ def main(page: ft.Page):
             [
                 new_message,
                 ft.IconButton(
-                    icon=ft.icons.SEND_ROUNDED,
+                    icon=ft.Icons.SEND_ROUNDED,
                     tooltip="Send message",
                     on_click=send_message_click,
                 ),

--- a/python/tutorials/chat/chat.py
+++ b/python/tutorials/chat/chat.py
@@ -63,7 +63,7 @@ def main(page: ft.Page):
             join_user_name.update()
         else:
             page.session.set("user_name", join_user_name.value)
-            page.dialog.open = False
+            welcome_dlg.open = False
             new_message.prefix = ft.Text(f"{join_user_name.value}: ")
             page.pubsub.send_all(
                 Message(
@@ -103,7 +103,7 @@ def main(page: ft.Page):
         autofocus=True,
         on_submit=join_chat_click,
     )
-    page.dialog = ft.AlertDialog(
+    welcome_dlg = ft.AlertDialog(
         open=True,
         modal=True,
         title=ft.Text("Welcome!"),
@@ -111,6 +111,8 @@ def main(page: ft.Page):
         actions=[ft.ElevatedButton(text="Join chat", on_click=join_chat_click)],
         actions_alignment=ft.MainAxisAlignment.END,
     )
+
+    page.overlay.append(welcome_dlg)
 
     # Chat messages
     chat = ft.ListView(


### PR DESCRIPTION
When executing chat example in my environment, some deprecation warnings are shown.

```bash
❯ poetry run python aichat/main.py
Installing flet-desktop 0.25.2 package...OK
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:106: DeprecationWarning: dialog is deprecated in version 0.23.0 and will be removed in version 0.26.0. Use Page.overlay.append(dialog) instead.
  page.dialog = ft.AlertDialog(
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:138: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  border=ft.border.all(1, ft.colors.OUTLINE),
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:147: DeprecationWarning: icons enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Icons enum instead.
  icon=ft.icons.SEND_ROUNDED,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:94: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  m = ft.Text(message.text, italic=True, color=ft.colors.BLACK45, size=12)
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:18: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  color=ft.colors.WHITE,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:39: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.AMBER,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:40: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.BLUE,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:41: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.BROWN,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:42: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.CYAN,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:43: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.GREEN,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:44: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.INDIGO,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:45: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.LIME,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:46: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.ORANGE,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:47: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.PINK,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:48: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.PURPLE,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:49: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.RED,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:50: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.TEAL,
/Users/yudaihayashi/Documents/my_repo/aichat/aichat/main.py:51: DeprecationWarning: colors enum is deprecated since version 0.25.0 and will be removed in version 0.28.0. Use Colors enum instead.
  ft.colors.YELLOW,

```

I fixed all warnings.

- `colors` enum → `Colors` enum
- `icons` enum → `Icons` enum
- `page.dialog` → `Page.overlay.append(dialog)`